### PR TITLE
Add 'stat_edge' parameter to `tck2connectome`

### DIFF
--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -46,6 +46,7 @@ def generate_conn_matrix(
             ),
             tck_weights_in=tck_weights,
             scale_length=length,
+            stat_edge="mean" if length else None,
             nthreads=cfg["opt.threads"],
         )
 


### PR DESCRIPTION
Adds missing parameter for computing mean of statistic (default is sum). PR adds this in to compute mean where appropriate.