### PR TITLE
Add tract extraction + surface analysis

### DIFF
--- a/docs/src/usage/analysis_levels/connectivity.md
+++ b/docs/src/usage/analysis_levels/connectivity.md
@@ -1,7 +1,9 @@
 # Connectivity level
 
-`connectivity` level is intended to generate structural connectivity matrices, providing
-information about the connectivity between pairs of regions from a parcellation.
+`connectivity` level is intended to generate useful output files that may be directly or
+indirectly useful for analysis, such as structural connectivity matrices (providing
+information about the connectivity between pairs of regions from a parcellation), or
+identifiy individual tracts using regions of interest.
 
 ## Level-specific optional arguments
 
@@ -9,3 +11,24 @@ information about the connectivity between pairs of regions from a parcellation.
 | :- | :- | :- |
 | `--atlas <atlas>` | `participant.connectivity.atlas` | volumetric atlas name (assumed to be processed) for connectivity matrix |
 | `--radius <radius>` | `participant.connectivity.radius` | distance (in mm) to map to nearest parcel (default: 2.00) |
+
+If you wish to query individual tracts using inclusion / exclusion ROIs, you may also
+do so. By default, only a tract-density map is generated from these. Additionally, if
+an associated surface can be found, end points of the tract are mapped to the surfaces.
+
+> [!NOTE]
+> End points are only mapped if an inflated surface can be found!
+
+| Argument | Config Key | Description |
+| :- | :- | :- |
+| `--vox-mm` | `participant.connectivity.vox_mm` | isotropic voxel size (in mm) or space-separated listed of voxel sizes to map tracts to |
+| `--surf-query` | `participant.connectivity.query_surf` | string query for bids entities associated with surfaces to perform ribbon constrained mapping of streamlines to (subject & session is assumed); surface type (e.g. white, pial, etc.) will be automatically identified |
+| `--include-query` | `participant.connectivity.query_include` | string query for bids entities associated with inclusion ROI(s) (subject & session is assumed) |
+| `--exclude-query` | `participant.connectivity.query_exclude` | string query for bids entities associated with exclusion ROI(s) (subject & session is assumed) |
+| `--truncate-query` | `participant.connectivity.query_truncate` | string query for bids entities associated with ROI(s) in which streamlines should be truncated if entered (subject & session is assumed) |
+
+> [!NOTE]
+> Either atlas or ROIs should be provided. The workflow will throw an error if both
+> are provided.
+
+<!-- TODO: add an example (can go under advanced) -->

--- a/docs/src/usage/analysis_levels/connectivity.md
+++ b/docs/src/usage/analysis_levels/connectivity.md
@@ -22,10 +22,8 @@ an associated surface can be found, end points of the tract are mapped to the su
 | Argument | Config Key | Description |
 | :- | :- | :- |
 | `--vox-mm` | `participant.connectivity.vox_mm` | isotropic voxel size (in mm) or space-separated listed of voxel sizes to map tracts to |
+| `--tract-query` | `participant.connectivity.query_tract` | string query for bids entities associated with tract (subject & session is assumed); associated ROIs should be part of dataset descriptions that contain 'include', 'exclude', 'stop' keywords for respective ROIs. |
 | `--surf-query` | `participant.connectivity.query_surf` | string query for bids entities associated with surfaces to perform ribbon constrained mapping of streamlines to (subject & session is assumed); surface type (e.g. white, pial, etc.) will be automatically identified |
-| `--include-query` | `participant.connectivity.query_include` | string query for bids entities associated with inclusion ROI(s) (subject & session is assumed) |
-| `--exclude-query` | `participant.connectivity.query_exclude` | string query for bids entities associated with exclusion ROI(s) (subject & session is assumed) |
-| `--truncate-query` | `participant.connectivity.query_truncate` | string query for bids entities associated with ROI(s) in which streamlines should be truncated if entered (subject & session is assumed) |
 
 > [!NOTE]
 > Either atlas or ROIs should be provided. The workflow will throw an error if both

--- a/src/nhp_dwiproc/app/analysis_levels/participant/connectivity.py
+++ b/src/nhp_dwiproc/app/analysis_levels/participant/connectivity.py
@@ -13,6 +13,13 @@ from nhp_dwiproc.workflow.diffusion import connectivity
 def run(cfg: dict[str, Any], logger: Logger) -> None:
     """Runner for connectivity analysis-level."""
     logger.info("Connectivity analysis-level")
+    if cfg.get("participant.connectivity.atlas") and (
+        cfg.get("participant.connectivity.query_surf")
+        or cfg.get("participant.connectivity.query_include")
+        or cfg.get("participant.connectivity.query_exclude")
+        or cfg.get("participant.connectivity.query_truncate")
+    ):
+        raise ValueError("Only one of atlas or ROIs should be provided")
     b2t = utils.io.load_b2t(cfg=cfg, logger=logger)
 
     # Filter b2t based on string query
@@ -52,5 +59,8 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
             logger.info(
                 f"Processing {(uid := utils.bids_name(**input_kwargs['input_group']))}"
             )
-            connectivity.generate_conn_matrix(**input_kwargs)
+            if cfg.get("participant.connectivity.atlas"):
+                connectivity.generate_conn_matrix(**input_kwargs)
+            else:
+                connectivity.extract_tract(**input_kwargs)
             logger.info(f"Completed processing for {uid}")

--- a/src/nhp_dwiproc/app/analysis_levels/participant/connectivity.py
+++ b/src/nhp_dwiproc/app/analysis_levels/participant/connectivity.py
@@ -37,9 +37,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
         b2t=dwi_b2t, keys=["sub", "ses", "run", "space"]
     )
     for group_vals, group in tqdm(
-        dwi_b2t.filter_multi(suffix="dwi", ext={"items": [".nii", ".nii.gz"]}).groupby(
-            groupby_keys
-        )
+        dwi_b2t.filter_multi(suffix="tractography", ext=".tck").groupby(groupby_keys)
     ):
         for _, row in group.ent.iterrows():
             input_kwargs: dict[str, Any] = {
@@ -61,6 +59,8 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
             )
             if cfg.get("participant.connectivity.atlas"):
                 connectivity.generate_conn_matrix(**input_kwargs)
-            else:
+            elif cfg.get("participant.connectivity.query_tract"):
                 connectivity.extract_tract(**input_kwargs)
+            else:
+                raise ValueError("No valid inputs provided for connectivity workflow")
             logger.info(f"Completed processing for {uid}")

--- a/src/nhp_dwiproc/app/cli/args/connectivity.py
+++ b/src/nhp_dwiproc/app/cli/args/connectivity.py
@@ -36,6 +36,17 @@ def add_connectivity_args(app_parser: BidsAppArgumentParser) -> None:
         map tracts to""",
     )
     connectivity_args.add_argument(
+        "--tract-query",
+        "--tract_query",
+        metavar="query",
+        dest="participant.connectivity.query_tract",
+        type=str,
+        default=None,
+        help="""string query for bids entities associated with tract (subject & session
+        is assumed);  associated ROIs should be part of dataset descriptions that
+        contain 'include', 'exclude', 'stop' keywords for respective ROIs.""",
+    )
+    connectivity_args.add_argument(
         "--surf-query",
         "--surf_query",
         metavar="query",
@@ -45,15 +56,4 @@ def add_connectivity_args(app_parser: BidsAppArgumentParser) -> None:
         help="""string query for bids entities associated with surfaces to perform
         ribbon constrained mapping of streamlines to (subject & session is assumed);
         surface type (e.g. white, pial, etc.) will be automatically identified""",
-    )
-    connectivity_args.add_argument(
-        "--tract-query",
-        "--tract_query",
-        metavar="query",
-        dest="participant.connectivity.query_tract",
-        type=str,
-        default=None,
-        help="""string query for bids entities associated with tract (subject & session
-        is assumed); associated ROIs should be part of dataset with
-        'include', 'exclude', 'stop' descriptions for respective ROIs.""",
     )

--- a/src/nhp_dwiproc/app/cli/args/connectivity.py
+++ b/src/nhp_dwiproc/app/cli/args/connectivity.py
@@ -27,7 +27,7 @@ def add_connectivity_args(app_parser: BidsAppArgumentParser) -> None:
     connectivity_args.add_argument(
         "--vox-mm",
         "--vox_mm",
-        metvar="voxel_size",
+        metavar="voxel_size",
         dest="participant.connectivity.vox_mm",
         type=float,
         nargs="*",
@@ -47,32 +47,13 @@ def add_connectivity_args(app_parser: BidsAppArgumentParser) -> None:
         surface type (e.g. white, pial, etc.) will be automatically identified""",
     )
     connectivity_args.add_argument(
-        "--include-query",
-        "--include_query",
+        "--tract-query",
+        "--tract_query",
         metavar="query",
-        dest="participant.connectivity.query_include",
+        dest="participant.connectivity.query_tract",
         type=str,
         default=None,
-        help="""string query for bids entities associated with inclusion ROI(s)
-        (subject & session is assumed)""",
-    )
-    connectivity_args.add_argument(
-        "--exclude-query",
-        "--exclude_query",
-        metavar="query",
-        dest="participant.connectivity.query_exclude",
-        type=str,
-        default=None,
-        help="""string query for bids entities associated with exclusion ROI(s)
-        (subject & session is assumed)""",
-    )
-    connectivity_args.add_argument(
-        "--truncate-query",
-        "--truncate_query",
-        metavar="query",
-        dest="participant.connectivity.query_truncate",
-        type=str,
-        default=None,
-        help="""string query for bids entities associated with ROI(s) in which
-        streamlines should be truncated if entered (subject & session is assumed)""",
+        help="""string query for bids entities associated with tract (subject & session
+        is assumed); associated ROIs should be part of dataset with
+        'include', 'exclude', 'stop' descriptions for respective ROIs.""",
     )

--- a/src/nhp_dwiproc/app/cli/args/connectivity.py
+++ b/src/nhp_dwiproc/app/cli/args/connectivity.py
@@ -24,3 +24,55 @@ def add_connectivity_args(app_parser: BidsAppArgumentParser) -> None:
         default=2,
         help="distance (in mm) to map to nearest parcel (default: %(default).2f)",
     )
+    connectivity_args.add_argument(
+        "--vox-mm",
+        "--vox_mm",
+        metvar="voxel_size",
+        dest="participant.connectivity.vox_mm",
+        type=float,
+        nargs="*",
+        default=None,
+        help="""isotropic voxel size (in mm) or space-separated listed of voxel sizes to
+        map tracts to""",
+    )
+    connectivity_args.add_argument(
+        "--surf-query",
+        "--surf_query",
+        metavar="query",
+        dest="participant.connectivity.query_surf",
+        type=str,
+        default=None,
+        help="""string query for bids entities associated with surfaces to perform
+        ribbon constrained mapping of streamlines to (subject & session is assumed);
+        surface type (e.g. white, pial, etc.) will be automatically identified""",
+    )
+    connectivity_args.add_argument(
+        "--include-query",
+        "--include_query",
+        metavar="query",
+        dest="participant.connectivity.query_include",
+        type=str,
+        default=None,
+        help="""string query for bids entities associated with inclusion ROI(s)
+        (subject & session is assumed)""",
+    )
+    connectivity_args.add_argument(
+        "--exclude-query",
+        "--exclude_query",
+        metavar="query",
+        dest="participant.connectivity.query_exclude",
+        type=str,
+        default=None,
+        help="""string query for bids entities associated with exclusion ROI(s)
+        (subject & session is assumed)""",
+    )
+    connectivity_args.add_argument(
+        "--truncate-query",
+        "--truncate_query",
+        metavar="query",
+        dest="participant.connectivity.query_truncate",
+        type=str,
+        default=None,
+        help="""string query for bids entities associated with ROI(s) in which
+        streamlines should be truncated if entered (subject & session is assumed)""",
+    )

--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -70,9 +70,9 @@ def extract_tract(
     ]
     truncate_rois = [
         mrtrix.TckeditMask(spec=mrtrix.TckeditVariousFile_2(fpath))
-        for fpath in input_data["anat"]["rois"]["mask"]
+        for fpath in input_data["anat"]["rois"]["stop"]
     ]
-    rois = [incl_rois, excl_rois, truncate_rois]
+    rois = [*incl_rois, *excl_rois, *truncate_rois]
     if len(rois) == 0:
         raise ValueError("No ROIs were provided")
 
@@ -83,7 +83,7 @@ def extract_tract(
         **input_group,
     )
 
-    tract_entities = BIDSEntities.from_path(rois[0])
+    tract_entities = BIDSEntities.from_path(rois[0].spec.obj)
     label = tract_entities.label
     hemi = tract_entities.hemi
     tckedit = mrtrix.tckedit(
@@ -104,7 +104,7 @@ def extract_tract(
         tracks=tckedit.tracks_out,
         tck_weights_in=tckedit.tck_weights_out,
         vox=cfg.get("participant.connectivity.vox_mm"),
-        template=rois[0],
+        template=rois[0].spec.obj,
         output=bids(hemi=hemi, label=label, suffix="tdi", ext=".nii.gz"),
         nthreads=cfg["opt.threads"],
     )
@@ -121,7 +121,7 @@ def extract_tract(
             tracks=tckedit.tracks_out,
             tck_weights_in=tckedit.tck_weights_out,
             vox=cfg.get("participant.connectivity.vox_mm"),
-            template=rois[0],
+            template=rois[0].spec.obj,
             ends_only=True,
             output=bids(hemi=hemi, label=label, suffix="tdi", ext=".nii.gz"),
             nthreads=cfg["opt.threads"],

--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -34,17 +34,10 @@ def generate_conn_matrix(
             tracks_in=input_data["dwi"]["tractography"]["tck"],
             nodes_in=input_data["dwi"]["atlas"],
             connectome_out=bids(
-                meas=meas,
-                desc="probabilisticTracking",
-                suffix="relmap",
-                ext=".csv",
+                meas=meas, desc="probabilisticTracking", suffix="relmap", ext=".csv"
             ),
             assignment_radial_search=cfg["participant.connectivity.radius"],
-            out_assignments=bids(
-                desc="assignment",
-                suffix="tractography",
-                ext=".txt",
-            ),
+            out_assignments=bids(desc="assignment", suffix="tractography", ext=".txt"),
             tck_weights_in=tck_weights,
             scale_length=length,
             stat_edge="mean" if length else None,

--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -117,6 +117,10 @@ def extract_tract(
     if not input_data["anat"]["surfs"].get("inflated"):
         logger.warning("Inflated surface not found; not mapping end points")
     else:
+        assert (
+            len(input_data["anat"]["surfs"][surf_type]) == 1
+            for surf_type in ["white", "pial", "inflated"]
+        ), "More than 1 surface for each type found"
         tdi_ends = mrtrix.tckmap(
             tracks=tckedit.tracks_out,
             tck_weights_in=tckedit.tck_weights_out,
@@ -128,13 +132,12 @@ def extract_tract(
         )
         surf_ends = workbench.volume_to_surface_mapping(
             volume=tdi_ends.output,
-            surface=input_data["anat"]["surfs"]["inflated"],
+            surface=input_data["anat"]["surfs"]["inflated"][0],
             metric_out=bids(hemi=hemi, label=label, suffix="conn", ext=".shape.gii"),
             ribbon_constrained=(
                 workbench.VolumeToSurfaceMappingRibbonConstrained(
-                    inner_surf=input_data["anat"]["surfs"]["white"],
-                    outer_surf=input_data["anat"]["surfs"]["pial"],
-                    roi_out="PLACEHOLDER_NAME.shape.gii",  # Not needed / to be removed
+                    inner_surf=input_data["anat"]["surfs"]["white"][0],
+                    outer_surf=input_data["anat"]["surfs"]["pial"][0],
                 )
             ),
         )

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/denoise.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/denoise.py
@@ -32,11 +32,7 @@ def denoise(
 
     denoise = mrtrix.dwidenoise(
         dwi=input_data["dwi"]["nii"],
-        out=bids(
-            desc="denoise",
-            suffix="dwi",
-            ext=".nii.gz",
-        ),
+        out=bids(desc="denoise", suffix="dwi", ext=".nii.gz"),
         estimator=cfg["participant.preprocess.denoise.estimator"],
         noise=bids(
             algorithm=cfg["participant.preprocess.denoise.estimator"],

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
@@ -103,11 +103,7 @@ def concat_bv(
     """Concatenate .bval and .bvec files."""
     out_dir = cfg["opt.working_dir"] / f"{gen_hash()}_concat-bv"
     bids = partial(
-        utils.bids_name,
-        datatype="dwi",
-        desc="concat",
-        suffix="dwi",
-        **input_group,
+        utils.bids_name, datatype="dwi", desc="concat", suffix="dwi", **input_group
     )
     out_dir.mkdir(parents=True, exist_ok=False)
     out_files = out_dir / bids(ext=".bval"), out_dir / bids(ext=".bvec")

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
@@ -37,10 +37,7 @@ def register(
         bzero=True,
         nthreads=cfg["opt.threads"],
         config=[
-            mrtrix.DwiextractConfig(
-                "BZeroThreshold",
-                str(cfg["participant.b0_thresh"]),
-            )
+            mrtrix.DwiextractConfig("BZeroThreshold", str(cfg["participant.b0_thresh"]))
         ],
     )
 

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/unring.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/unring.py
@@ -18,11 +18,7 @@ def degibbs(
     **kwargs,
 ) -> OutputPathType:
     """Minimize Gibbs ringing."""
-    bids = partial(
-        utils.bids_name,
-        datatype="dwi",
-        **entities,
-    )
+    bids = partial(utils.bids_name, datatype="dwi", **entities)
     if cfg["participant.preprocess.unring.skip"]:
         return OutputPathType(dwi)
 
@@ -30,11 +26,7 @@ def degibbs(
 
     degibbs = mrtrix.mrdegibbs(
         in_=dwi,
-        out=bids(
-            desc="unring",
-            suffix="dwi",
-            ext=".nii.gz",
-        ),
+        out=bids(desc="unring", suffix="dwi", ext=".nii.gz"),
         axes=cfg.get("participant.preprocess.unring.axes"),
         nshifts=cfg["participant.preprocess.unring.nshifts"],
         min_w=cfg["participant.preprocess.unring.minW"],

--- a/src/nhp_dwiproc/workflow/diffusion/tractography.py
+++ b/src/nhp_dwiproc/workflow/diffusion/tractography.py
@@ -54,27 +54,16 @@ def generate_tractography(
     """Generate subject tractography."""
     logger.info("Generating tractography")
     wm_fod = fod.input_output[0].output
-    bids = partial(
-        utils.bids_name,
-        datatype="dwi",
-        **input_group,
-    )
+    bids = partial(utils.bids_name, datatype="dwi", **input_group)
     tckgen = _tckgen(
-        wm_fod=wm_fod,
-        tt_map=input_data["dwi"].get("5tt", None),
-        bids=bids,
-        cfg=cfg,
+        wm_fod=wm_fod, tt_map=input_data["dwi"].get("5tt", None), bids=bids, cfg=cfg
     )
 
     logger.info("Computing per-streamline multipliers")
     tcksift = mrtrix.tcksift2(
         in_tracks=tckgen.tracks,
         in_fod=wm_fod,
-        out_weights=bids(
-            method="SIFT2",
-            suffix="tckWeights",
-            ext=".txt",
-        ),
+        out_weights=bids(method="SIFT2", suffix="tckWeights", ext=".txt"),
         nthreads=cfg["opt.threads"],
     )
 
@@ -84,11 +73,7 @@ def generate_tractography(
             tracks=tckgen.tracks,
             tck_weights_in=weights,
             template=wm_fod,
-            output=bids(
-                meas=meas,
-                suffix="tdi",
-                ext=".nii.gz",
-            ),
+            output=bids(meas=meas, suffix="tdi", ext=".nii.gz"),
             nthreads=cfg["opt.threads"],
         )
 

--- a/src/nhp_dwiproc/workflow/diffusion/tractography.py
+++ b/src/nhp_dwiproc/workflow/diffusion/tractography.py
@@ -1,4 +1,4 @@
-"""Tractography generation."""
+"""Tractography-related operations."""
 
 from functools import partial
 from logging import Logger


### PR DESCRIPTION
Add another post-reconst workflow, this time enabling extraction of individual tracts and mapping endpoints to surfaces if found.
This currently assumes some bids key naming, which may change later on.