### PR TITLE
Update surface mapping

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [StyxSingularity](./runners/styxsingularity.md)
   - [Advanced](./usage/advanced/README.md)
     - [Anatomically constrained tractography](./usage/advanced/act.md)
+    - [Surface mapping](./usage/advanced/tract.md)
 
 # Miscellaneous
 

--- a/docs/src/usage/advanced/tract.md
+++ b/docs/src/usage/advanced/tract.md
@@ -1,0 +1,18 @@
+# Surface mapping of tracts
+
+Individual tracts can be extracted and mapped to a surface. To help facilitate this
+process, additional string query arguments can be used. Tracts are extracted with the
+aid of inclusion and exclusion regions of interests (ROIs). Below is an example
+command used to extract a single tract and perform surface mapping.
+
+```bash
+nhp_dwiproc <bids_dir> <output_dir> connectivity \
+  --config <path/to/config.yaml> \
+  --participant-query "sub=='example'" \
+  --tract-query "hemi=='L' & label=='tract'" \
+  --surf-query "hemi=='L'
+```
+
+> [!NOTE]
+> `hemi` and `label` are associated with the entities, while the tract extracted in the
+> previous example is "tract" of the left hemisphere.

--- a/docs/src/usage/analysis_levels/connectivity.md
+++ b/docs/src/usage/analysis_levels/connectivity.md
@@ -14,10 +14,14 @@ identifiy individual tracts using regions of interest.
 
 If you wish to query individual tracts using inclusion / exclusion ROIs, you may also
 do so. By default, only a tract-density map is generated from these. Additionally, if
-an associated surface can be found, end points of the tract are mapped to the surfaces.
+an associated surface can be found, tracts passing through the cortical ribbon are
+mapped to the surface.
 
 > [!NOTE]
-> End points are only mapped if an inflated surface can be found!
+> - Tracts are only mapped if an inflated surface can be found!
+> - Non-lateralized tracts will need to be mapped twice, once for each hemisphere.
+
+
 
 | Argument | Config Key | Description |
 | :- | :- | :- |
@@ -29,4 +33,4 @@ an associated surface can be found, end points of the tract are mapped to the su
 > Either atlas or ROIs should be provided. The workflow will throw an error if both
 > are provided.
 
-<!-- TODO: add an example (can go under advanced) -->
+An surface mapping example can be found [here](../advanced/tract.md), under the advanced pages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "eddymotion>=0.1.15",
   "nifti",
   # (Temporary) pinned versions of packages to fix errors
-  "nitransforms>=24.0.2"
+  "nitransforms==24.0.1"
 ]
 keywords = ["nhp", "diffusion mri", "processing"]
 classifiers = [

--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -121,17 +121,8 @@ def extract_tract(
             len(input_data["anat"]["surfs"][surf_type]) == 1
             for surf_type in ["white", "pial", "inflated"]
         ), "More than 1 surface for each type found"
-        tdi_ends = mrtrix.tckmap(
-            tracks=tckedit.tracks_out,
-            tck_weights_in=tckedit.tck_weights_out,
-            vox=cfg.get("participant.connectivity.vox_mm"),
-            template=rois[0].spec.obj,
-            ends_only=True,
-            output=bids(hemi=hemi, label=label, suffix="tdi", ext=".nii.gz"),
-            nthreads=cfg["opt.threads"],
-        )
-        surf_ends = workbench.volume_to_surface_mapping(
-            volume=tdi_ends.output,
+        surf = workbench.volume_to_surface_mapping(
+            volume=tdi.output,
             surface=input_data["anat"]["surfs"]["inflated"][0],
             metric_out=bids(hemi=hemi, label=label, suffix="conn", ext=".shape.gii"),
             ribbon_constrained=(
@@ -143,6 +134,6 @@ def extract_tract(
         )
 
         utils.io.save(
-            files=surf_ends.metric_out,
+            files=surf.metric_out,
             out_dir=cfg["output_dir"].joinpath(bids(directory=True)),
         )


### PR DESCRIPTION
Updates surface mapping, removing redundant step. Also reverts nitransform dependency update back to pinned `24.0.1` which fixes issue with `eddymotion`