### PR TITLE
Update atlas entities

### DIFF
--- a/src/nhp_dwiproc/app/utils/io.py
+++ b/src/nhp_dwiproc/app/utils/io.py
@@ -165,6 +165,7 @@ def get_inputs(
                     entities={
                         "datatype": "anat",
                         "desc": None,
+                        "method": None,
                         "seg": cfg.get("participant.connectivity.atlas", ""),
                         "suffix": "dseg",
                         "ext": {"items": [".nii", ".nii.gz"]},


### PR DESCRIPTION
Set `method=None` when grabbing initial atlas since this is grabbing the nifti based on tractography entities.