### PR TITLE
Update path for grad checked bvec file

### DIFF
--- a/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
+++ b/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
@@ -250,7 +250,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
         dwi_lib.grad_check(nii=dwi, bvec=bvec, bval=bval_fpath, mask=mask, cfg=cfg)
 
         # Create JSON sidecar
-        json_fpath = pl.Path(str(bval_fpath).replace(".bval", ".json"))
+        json_fpath = bval_fpath.with_suffix(".json")
         json_fpath.write_text(
             json.dumps(input_kwargs["input_data"]["dwi"]["json"], indent=2)
         )

--- a/src/nhp_dwiproc/lib/dwi.py
+++ b/src/nhp_dwiproc/lib/dwi.py
@@ -194,7 +194,7 @@ def grad_check(
             bvals=bval,
         ),
         export_grad_fsl=mrtrix.DwigradcheckExportGradFsl(
-            bvecs_path=bvec.name,
+            bvecs_path=bval.with_suffix(".bvec").name,
             bvals_path=bval.name,  # replacing file if necessary
         ),
         nthreads=cfg["opt.threads"],
@@ -202,5 +202,5 @@ def grad_check(
 
     utils.io.save(
         files=bvec_check.export_grad_fsl_.bvecs_path,
-        out_dir=bvec.parent,
+        out_dir=bval.parent,
     )

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
@@ -173,7 +173,6 @@ def apply_transform(
         files=[
             xfm_dwi.output.output_image_outfile,
             xfm_mask.output.output_image_outfile,
-            xfm_bvec,
         ],
         out_dir=cfg["output_dir"].joinpath(bids(directory=True)),
     )


### PR DESCRIPTION
The bvec file after running `Mrtrix`'s grad check was being exported to the same location, resulting in it not getting saved. This PR uses the saved `bval` path, replacing the suffix with the ".bvec" extension, guaranteeing the file is saved at the appropriate location. 

Additionally, also updates the renaming of the json_fpath using the same `with_suffix` method. 