### PR TITLE
Fix missing BZeroThreshold 

### DIFF
--- a/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
+++ b/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
@@ -53,7 +53,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
 
         # Inner loop process per direction, save to list
         dir_outs = defaultdict(list)
-        for idx, row in group.ent.iterrows():
+        for idx, (_, row) in enumerate(group.ent.iterrows()):
             input_kwargs["input_data"] = utils.io.get_inputs(
                 b2t=b2t,
                 row=row,

--- a/src/nhp_dwiproc/lib/dwi.py
+++ b/src/nhp_dwiproc/lib/dwi.py
@@ -14,10 +14,7 @@ from nhp_dwiproc.utils.assets import load_nifti
 
 
 def get_phenc_info(
-    idx: int,
-    input_data: dict[str, Any],
-    logger: Logger,
-    **kwargs,
+    idx: int, input_data: dict[str, Any], logger: Logger, **kwargs
 ) -> tuple[str, np.ndarray]:
     """Generate phase encode information file."""
     # Gather relevant metadata

--- a/src/nhp_dwiproc/lib/dwi.py
+++ b/src/nhp_dwiproc/lib/dwi.py
@@ -184,7 +184,6 @@ def grad_check(
     bvec: pl.Path,
     bval: pl.Path,
     mask: pl.Path | None,
-    cfg: dict[str, Any],
     **kwargs,
 ) -> None:
     """Check and update orientation of diffusion gradient."""
@@ -192,20 +191,13 @@ def grad_check(
         input_image=nii,
         mask_image=mask,
         number=10_000,  # Small number to enable quick permutations,
-        fslgrad=mrtrix.DwigradcheckFslgrad(
-            bvecs=bvec,
-            bvals=bval,
-        ),
+        fslgrad=mrtrix.DwigradcheckFslgrad(bvecs=bvec, bvals=bval),
         export_grad_fsl=mrtrix.DwigradcheckExportGradFsl(
             bvecs_path=bval.with_suffix(".bvec").name,
             bvals_path=bval.name,  # replacing file if necessary
         ),
-        nthreads=cfg["opt.threads"],
     )
     if not bvec_check.export_grad_fsl_:
         raise AttributeError("Unsuccessful export of diffusion gradients")
 
-    utils.io.save(
-        files=bvec_check.export_grad_fsl_.bvecs_path,
-        out_dir=bval.parent,
-    )
+    utils.io.save(files=bvec_check.export_grad_fsl_.bvecs_path, out_dir=bval.parent)

--- a/src/nhp_dwiproc/lib/dwi.py
+++ b/src/nhp_dwiproc/lib/dwi.py
@@ -10,6 +10,7 @@ from niwrap import mrtrix
 
 import nhp_dwiproc.utils as utils
 from nhp_dwiproc.lib import metadata
+from nhp_dwiproc.utils.assets import load_nifti
 
 
 def get_phenc_info(
@@ -37,7 +38,7 @@ def get_phenc_info(
         pe_vec[np.where(pe_vec > 0)] = -1
 
     # Generate phase encoding data for use
-    img = nib.load(input_data["dwi"]["nii"])
+    img = load_nifti(input_data["dwi"]["nii"])
     img_size = np.array(img.header.get_data_shape())
     num_phase_encodes = img_size[np.where(np.abs(pe_vec) > 0)]
     ro_time = eff_echo * (num_phase_encodes - 1)
@@ -132,7 +133,7 @@ def get_eddy_indices(
     cfg: dict[str, Any],
 ) -> pl.Path:
     """Generate dwi index file for eddy."""
-    imsizes = [nib.load(nii).header.get_data_shape() for nii in niis]
+    imsizes = [load_nifti(nii).header.get_data_shape() for nii in niis]
 
     eddy_idxes = [
         idx if len(imsize) < 4 else [idx] * imsize[3]

--- a/src/nhp_dwiproc/utils/app.py
+++ b/src/nhp_dwiproc/utils/app.py
@@ -45,7 +45,10 @@ def initialize(cfg: dict[str, Any]) -> tuple[logging.Logger, Runner]:
         )
 
     runner.data_dir = cfg["opt.working_dir"]
-    runner.environ = {"MRTRIX_RNG_SEED": str(cfg["opt.seed_num"])}
+    runner.environ = {
+        "MRTRIX_NTHREADS": str(cfg.get("opt.threads")),
+        "MRTRIX_RNG_SEED": str(cfg.get("opt.seed_num")),
+    }
     set_global_runner(GraphRunner(runner))
 
     logger = logging.getLogger(runner.logger_name)

--- a/src/nhp_dwiproc/workflow/diffusion/connectivity.py
+++ b/src/nhp_dwiproc/workflow/diffusion/connectivity.py
@@ -19,11 +19,7 @@ def generate_conn_matrix(
 ) -> None:
     """Generate connectivity matrix."""
     logger.info("Generating connectivity matrices")
-    bids = partial(
-        utils.io.bids_name,
-        datatype="dwi",
-        **input_group,
-    )
+    bids = partial(utils.io.bids_name, datatype="dwi", **input_group)
     tck2connectome = {}
     for meas, tck_weights, length in zip(
         ["afd", "count", "avgLength"],
@@ -41,7 +37,6 @@ def generate_conn_matrix(
             tck_weights_in=tck_weights,
             scale_length=length,
             stat_edge="mean" if length else None,
-            nthreads=cfg["opt.threads"],
         )
 
         # Save outputs
@@ -77,11 +72,7 @@ def extract_tract(
         raise ValueError("No ROIs were provided")
 
     logger.info("Extracting tract")
-    bids = partial(
-        utils.io.bids_name,
-        datatype="dwi",
-        **input_group,
-    )
+    bids = partial(utils.io.bids_name, datatype="dwi", **input_group)
 
     tract_entities = BIDSEntities.from_path(rois[0].spec.obj)
     label = tract_entities.label
@@ -98,7 +89,6 @@ def extract_tract(
         tck_weights_out=bids(
             hemi=hemi, label=label, method="SIFT2", suffix="tckWeights", ext=".txt"
         ),
-        nthreads=cfg["opt.threads"],
     )
     tdi = mrtrix.tckmap(
         tracks=tckedit.tracks_out,
@@ -106,7 +96,6 @@ def extract_tract(
         vox=[vox] if (vox := cfg.get("participant.connectivity.vox_mm")) else None,
         template=rois[0].spec.obj,
         output=bids(hemi=hemi, label=label, suffix="tdi", ext=".nii.gz"),
-        nthreads=cfg["opt.threads"],
     )
 
     utils.io.save(

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/biascorrect.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/biascorrect.py
@@ -32,7 +32,6 @@ def biascorrect(
         ants_b=f"{cfg['participant.preprocess.biascorrect.spacing']},3",
         ants_c=f"{cfg['participant.preprocess.biascorrect.iters']},0.0",
         ants_s=f"{cfg['participant.preprocess.biascorrect.shrink']}",
-        nthreads=cfg["opt.threads"],
     )
     biascorrect = mrtrix.dwibiascorrect(
         input_image=biascorrect.output_image_file,
@@ -42,14 +41,12 @@ def biascorrect(
         ants_b=f"{cfg['participant.preprocess.biascorrect.spacing']},3",
         ants_c=f"{cfg['participant.preprocess.biascorrect.iters']},0.0",
         ants_s=f"{cfg['participant.preprocess.biascorrect.shrink']}",
-        nthreads=cfg["opt.threads"],
     )
 
     mask = mrtrix.dwi2mask(
         input_=biascorrect.output_image_file,
         output=bids(desc="biascorrect", suffix="mask"),
         fslgrad=mrtrix.Dwi2maskFslgrad(bvecs=bvec, bvals=bval),
-        nthreads=cfg["opt.threads"],
     )
 
     utils.io.save(

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/denoise.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/denoise.py
@@ -43,7 +43,6 @@ def denoise(
         if (noise_map := cfg["participant.preprocess.denoise.map"])
         else None,
         extent=cfg.get("participant.preprocess.denoise.extent"),
-        nthreads=cfg["opt.threads"],
     )
 
     if noise_map:

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
@@ -36,10 +36,8 @@ def get_phenc_data(
         output=bids(ext=".mif"),
         bzero=True,
         fslgrad=mrtrix.DwiextractFslgrad(
-            bvals=input_data["dwi"]["bval"],
-            bvecs=input_data["dwi"]["bvec"],
+            bvals=input_data["dwi"]["bval"], bvecs=input_data["dwi"]["bvec"]
         ),
-        nthreads=cfg["opt.threads"],
     )
 
     dwi_b0 = mrtrix.mrconvert(
@@ -47,7 +45,6 @@ def get_phenc_data(
         output=bids(ext=".nii.gz"),
         coord=[mrtrix.MrconvertCoord(3, [0])],
         axes=[0, 1, 2],
-        nthreads=cfg["opt.threads"],
     )
 
     pe_dir, pe_data = get_phenc_info(
@@ -56,11 +53,7 @@ def get_phenc_data(
         cfg=cfg,
         logger=logger,
     )
-    return (
-        dwi_b0.output,
-        pe_dir,
-        pe_data,
-    )
+    return dwi_b0.output, pe_dir, pe_data
 
 
 def gen_topup_inputs(
@@ -76,16 +69,13 @@ def gen_topup_inputs(
         output=utils.io.bids_name(
             datatype="dwi", suffix="b0", ext=".nii.gz", **input_group
         ),
-        nthreads=cfg["opt.threads"],
     )
     dwi_b0 = dwi_b0.output
     dwi_fpath = normalize(dwi_b0, input_group=input_group, cfg=cfg)
 
     # Get matching PE data to b0
     phenc_fpath = concat_dir_phenc_data(
-        pe_data=dir_outs["pe_data"],
-        input_group=input_group,
-        cfg=cfg,
+        pe_data=dir_outs["pe_data"], input_group=input_group, cfg=cfg
     )
     pe_indices = get_pe_indices(dir_outs["pe_dir"])
 
@@ -135,7 +125,6 @@ def gen_eddy_inputs(
                 ext=".nii.gz",
                 **input_group,
             ),
-            nthreads=cfg["opt.threads"],
         )
         dwi = dwi.output
     else:
@@ -153,9 +142,7 @@ def gen_eddy_inputs(
     # Generate phenc file if necessary
     if not phenc:
         phenc = concat_dir_phenc_data(
-            pe_data=[dir_outs["pe_data"][0]],
-            input_group=input_group,
-            cfg=cfg,
+            pe_data=[dir_outs["pe_data"][0]], input_group=input_group, cfg=cfg
         )
 
     # Generate index file

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/dwi.py
@@ -38,6 +38,9 @@ def get_phenc_data(
         fslgrad=mrtrix.DwiextractFslgrad(
             bvals=input_data["dwi"]["bval"], bvecs=input_data["dwi"]["bvec"]
         ),
+        config=[
+            mrtrix.DwiextractConfig("BZeroThreshold", str(cfg["participant.b0_thresh"]))
+        ],
     )
 
     dwi_b0 = mrtrix.mrconvert(

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/eddy.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/eddy.py
@@ -40,7 +40,6 @@ def run_eddy(
             input_=dwi,
             output=bids(desc="preEddy", suffix="mask"),
             fslgrad=mrtrix.Dwi2maskFslgrad(bvecs=bvec, bvals=bval),
-            nthreads=cfg["opt.threads"],
         ).output
 
     logger.info("Running FSL's eddy")

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
@@ -8,12 +8,12 @@ from functools import partial
 from logging import Logger
 from typing import Any
 
-import nibabel.nifti1 as nib
 from niwrap import ants, c3d, greedy, mrtrix
 from styxdefs import InputPathType, OutputPathType
 
 import nhp_dwiproc.utils as utils
 from nhp_dwiproc.lib.dwi import rotate_bvec
+from nhp_dwiproc.utils.assets import load_nifti
 
 
 def register(
@@ -88,7 +88,7 @@ def register(
         raise ValueError("b0 image was unable to be resliced.")
 
     # Create reference in original resolution
-    im = nib.load(b0.output)
+    im = load_nifti(b0.output)
     res = "x".join([str(vox) for vox in im.header.get_zooms()]) + "mm"
     ref_b0 = c3d.c3d_(
         input_=[b0_resliced.reslice_moving_image.resliced_image],

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/registration.py
@@ -35,7 +35,6 @@ def register(
         output=bids(suffix="b0", ext=".mif"),
         fslgrad=mrtrix.DwiextractFslgrad(bvecs=bvec, bvals=bval),
         bzero=True,
-        nthreads=cfg["opt.threads"],
         config=[
             mrtrix.DwiextractConfig("BZeroThreshold", str(cfg["participant.b0_thresh"]))
         ],
@@ -46,7 +45,6 @@ def register(
         output=bids(desc="avg", suffix="b0", ext=".nii.gz"),
         operation="mean",
         axis=3,
-        nthreads=cfg["opt.threads"],
     )
 
     # Perform registration

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/unring.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/unring.py
@@ -31,7 +31,6 @@ def degibbs(
         nshifts=cfg["participant.preprocess.unring.nshifts"],
         min_w=cfg["participant.preprocess.unring.minW"],
         max_w=cfg["participant.preprocess.unring.maxW"],
-        nthreads=cfg["opt.threads"],
     )
 
     return degibbs.out

--- a/src/nhp_dwiproc/workflow/diffusion/reconst.py
+++ b/src/nhp_dwiproc/workflow/diffusion/reconst.py
@@ -47,10 +47,8 @@ def compute_fods(
         input_=input_data["dwi"]["nii"],
         output=input_data["dwi"]["nii"].name.replace(".nii.gz", ".mif"),
         fslgrad=mrtrix.MrconvertFslgrad(
-            bvecs=input_data["dwi"]["bvec"],
-            bvals=input_data["dwi"]["bval"],
+            bvecs=input_data["dwi"]["bvec"], bvals=input_data["dwi"]["bval"]
         ),
-        nthreads=cfg["opt.threads"],
     )
     dwi2response = mrtrix.dwi2response(
         algorithm=mrtrix.Dwi2responseDhollander(
@@ -62,7 +60,6 @@ def compute_fods(
         mask=input_data["dwi"]["mask"],
         shells=cfg.get("participant.tractography.shells"),
         lmax=cfg.get("participant.tractography.lmax"),
-        nthreads=cfg["opt.threads"],
         config=[
             mrtrix.Dwi2responseConfig(
                 "BZeroThreshold", (b0_thresh := str(cfg["participant.b0_thresh"]))
@@ -94,7 +91,6 @@ def compute_fods(
             dwi=mrconvert.output,
             response_odf=response_odf,  # type: ignore
             mask=input_data["dwi"]["mask"],
-            nthreads=cfg["opt.threads"],
             config=[mrtrix3tissue.Ss3tCsdBeta1Config("BZeroThreshold", b0_thresh)],
         )
     else:
@@ -113,7 +109,6 @@ def compute_fods(
             response_odf=response_odf,  # type: ignore
             mask=input_data["dwi"]["mask"],
             shells=cfg.get("participant.tractography.shells"),
-            nthreads=cfg["opt.threads"],
             config=[mrtrix.Dwi2fodConfig("BZeroThreshold", b0_thresh)],
         )
 
@@ -126,9 +121,7 @@ def compute_fods(
         for tissue_odf in odfs.response_odf
     ]
     mtnormalise = mrtrix.mtnormalise(
-        input_output=normalize_odf,
-        mask=input_data["dwi"]["mask"],
-        nthreads=cfg["opt.threads"],
+        input_output=normalize_odf, mask=input_data["dwi"]["mask"]
     )
 
     return mtnormalise
@@ -155,11 +148,9 @@ def compute_dti(
         dwi=input_data["dwi"]["nii"],
         dt=bids(),
         fslgrad=mrtrix.Dwi2tensorFslgrad(
-            bvecs=input_data["dwi"]["bvec"],
-            bvals=input_data["dwi"]["bval"],
+            bvecs=input_data["dwi"]["bvec"], bvals=input_data["dwi"]["bval"]
         ),
         mask=input_data["dwi"]["mask"],
-        nthreads=cfg["opt.threads"],
         config=[
             mrtrix.Dwi2tensorConfig(
                 "BZeroThreshold", (b0_thresh := str(cfg["participant.b0_thresh"]))
@@ -178,7 +169,6 @@ def compute_dti(
         value=bids(param="S1"),
         vector=bids(param="V1"),
         num=[1],
-        nthreads=cfg["opt.threads"],
         config=[mrtrix.Tensor2metricConfig("BZeroThreshold", b0_thresh)],
     )
 

--- a/src/nhp_dwiproc/workflow/diffusion/tractography.py
+++ b/src/nhp_dwiproc/workflow/diffusion/tractography.py
@@ -27,7 +27,6 @@ def _tckgen(
         "step": cfg.get("participant.tractography.steps"),
         "cutoff": cfg.get("participant.tractography.cutoff"),
         "select_": cfg.get("participant.tractography.streamlines"),
-        "nthreads": cfg.get("opt.threads"),
     }
 
     # ACT-specific params
@@ -64,7 +63,6 @@ def generate_tractography(
         in_tracks=tckgen.tracks,
         in_fod=wm_fod,
         out_weights=bids(method="SIFT2", suffix="tckWeights", ext=".txt"),
-        nthreads=cfg["opt.threads"],
     )
 
     tdi = {}
@@ -74,7 +72,6 @@ def generate_tractography(
             tck_weights_in=weights,
             template=wm_fod,
             output=bids(meas=meas, suffix="tdi", ext=".nii.gz"),
-            nthreads=cfg["opt.threads"],
         )
 
     # Save relevant outputs


### PR DESCRIPTION
* Simplify passing of `nthreads` to Mrtrix wrapper
* Replace `nib.load` calls with `load_nifti`, taking advantage of `nifti` library
* Added missing `BZeroThreshold` configs for `mrtrix.dwiextract`
* Fix indexing passing for distortion correction.

Resolves  #59 