### PR TITLE
Remove crude mask generation from topup

### DIFF
--- a/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
+++ b/src/nhp_dwiproc/app/analysis_levels/participant/preprocess.py
@@ -90,7 +90,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
                     cfg["participant.preprocess.topup.skip"] = True
 
                 if not cfg["participant.preprocess.topup.skip"]:
-                    phenc, indices, topup, eddy_mask = preprocess.topup.run_apply_topup(
+                    phenc, indices, topup = preprocess.topup.run_apply_topup(
                         dir_outs=dir_outs, **input_kwargs
                     )
                 else:
@@ -104,7 +104,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
                         phenc=phenc,
                         indices=indices,
                         topup=topup,
-                        mask=eddy_mask,
+                        mask=None,
                         dir_outs=dir_outs,
                         **input_kwargs,
                     )
@@ -159,7 +159,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
                     cfg["participant.preprocess.topup.skip"] = True
 
                 if not cfg["participant.preprocess.topup.skip"]:
-                    phenc, indices, topup, eddy_mask = preprocess.topup.run_apply_topup(
+                    phenc, indices, topup = preprocess.topup.run_apply_topup(
                         dir_outs=dir_outs, **input_kwargs
                     )
                     for key in dir_outs.keys():
@@ -175,7 +175,7 @@ def run(cfg: dict[str, Any], logger: Logger) -> None:
                         phenc=phenc,
                         indices=indices,
                         topup=topup,
-                        mask=eddy_mask,
+                        mask=None,
                         dir_outs=dir_outs,
                         **input_kwargs,
                     )

--- a/src/nhp_dwiproc/workflow/diffusion/preprocess/topup.py
+++ b/src/nhp_dwiproc/workflow/diffusion/preprocess/topup.py
@@ -5,8 +5,7 @@ from functools import partial
 from logging import Logger
 from typing import Any
 
-from niwrap import fsl, mrtrix
-from styxdefs import OutputPathType
+from niwrap import fsl
 
 import nhp_dwiproc.utils as utils
 from nhp_dwiproc.workflow.diffusion.preprocess.dwi import gen_topup_inputs
@@ -18,7 +17,7 @@ def run_apply_topup(
     cfg: dict[str, Any],
     logger: Logger,
     **kwargs,
-) -> tuple[pl.Path, list[str], fsl.TopupOutputs, OutputPathType]:
+) -> tuple[pl.Path, list[str], fsl.TopupOutputs]:
     """Perform FSL's topup."""
     bids = partial(
         utils.io.bids_name, datatype="dwi", desc="topup", ext=".nii.gz", **input_group
@@ -40,17 +39,4 @@ def run_apply_topup(
     if not topup.iout:
         raise ValueError("Unable to unwarp b0")
 
-    # Generate crude mask for eddy
-    mean_topup = mrtrix.mrmath(
-        input_=[topup.iout],
-        operation="mean",
-        output=bids(desc="mean", suffix="b0"),
-        axis=3,
-    )
-    mask = fsl.bet(
-        infile=mean_topup.output,
-        maskfile=bids(desc="preEddy", suffix="brain", ext=None),
-        binary_mask=True,
-    )
-
-    return phenc, indices, topup, mask.binary_mask
+    return phenc, indices, topup


### PR DESCRIPTION
This isn't strictly necessary since a crude mask can also be generated in the eddy step and a final mask is generated in the biascorrection map. This can also introduce differences in the header which causes eddy to error out.